### PR TITLE
Added a cpp path tokenizer that works with std::string

### DIFF
--- a/hw3/stringTokenizer.cpp
+++ b/hw3/stringTokenizer.cpp
@@ -1,0 +1,26 @@
+#include <vector>
+#include <string>
+#include "stringTokenizer.h"
+
+std::vector<std::string> tokenizeStringPath(std::string p){
+	int pos = -1;
+	std::vector<std::string> v;
+	while((pos = p.find('/'))!=-1){
+		std::string dir = p.substr(0, pos);
+		v.push_back(dir);
+		p = p.substr(pos+1);
+	};
+
+	//* uncomment if you want to have / for paths starting from root. Currently it is ""(empty string) instead of "/"
+	// if(v.size()){
+	// 	if(v[0] == ""){
+	// 		v[0]="/";
+	// 	}
+	// }
+
+	if(p.size()){
+		v.push_back(p);
+	}
+
+	return v;
+}

--- a/hw3/stringTokenizer.h
+++ b/hw3/stringTokenizer.h
@@ -1,0 +1,15 @@
+#ifndef HW3_STRTOKENIZER_H
+#define HW3_STRTOKENIZER_H
+#include <vector>
+#include <string>
+
+/**
+ * Converts the path 'p' into tokenized set of strings. p needs to be a path string, e.g. "/home/a/b/c.txt".
+ * 
+ * Returns: vector<string>
+ * 
+ * You also have the option to get "/" as the root element, instead of an empty string "". Check the .cpp file for that.
+ */
+std::vector<std::string> tokenizeStringPath(std::string p);
+
+#endif //HW3_STRTOKENIZER_H


### PR DESCRIPTION
This version adds the same tokenizer, but it works with c++ std::string's instead of c char pointers.
You also have the option to specify '/' as the root token.
This version does not need any memory cleaning.